### PR TITLE
Add os-string to list of core libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Current list of Core Libraries:
 * `entropy`,
 * `filepath`,
 * `mtl`,
+* `os-string`,
 * `primitive`,
 * `process`,
 * `random`,


### PR DESCRIPTION
Since filepath now depends on os-string (since 1.5.0.0) and os-string is shipped with GHC as of 9.10, I think it makes sense to add this here. Since I'm the author and maintainer of os-string, this PR also serves as an explicit request of CLC taking over ownership.

