### PR TITLE
Add section about portability

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,3 +97,19 @@ to suggest for a core library (including one that affects several), please start
 the maintainer(s) and/or main source repositories, as listed on Hackage. If the maintainer
 is unsure of whether to proceed, they can come to the CLC for further guidance. On the other
 hand, if you struggle to reach a responsive maintainer, come to the CLC directly.
+
+## Portability
+
+It is a priority of the CLC and the library maintainers to
+ensure that core libraries remain portable. Core libraries are the building blocks
+of the ecosystem and it's important that the same libraries are available to be used
+on a variety of operating systems and architectures.
+
+In particular:
+
+* Libraries should remain compatible with a large range of platforms. Including but
+  not exclusive to standard linux distributions (aarch64 and x86_64), darwin systems and windows.
+* Libraries should avoid using features which not all backends support such as `TemplateHaskell`.
+  For boot libraries, this is a hard requirement.
+
+


### PR DESCRIPTION
I have added a section to the README which explains how platform portability should be a key consideration for the maintenance of core libraries.

There have been a couple of instances recently where `TemplateHaskell` has been used in core libraries which had meant they couldn't be built on some platforms. It seems helpful to just write down what the expectations are for maintainers of core libraries so they remain usable for everyone!

* https://github.com/haskell/directory/pull/193
* https://github.com/haskell/os-string/pull/21