### PR TITLE
Clarify status of bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ core-libraries-committee at haskell dot org
 ## `base` package
 
 The primary responsibility of CLC is to manage API changes of `base` package. The ownership of `base` belongs to GHC developers, and they can maintain it freely without CLC involvement as long as changes are invisible to clients. Changes which affect performance or laziness and similar are deemed visible. Documentation changes normally fall under GHC developers purview, except significant ones (e. g., adding or changing type class laws).
-Proposals to change the API of the `base` package are managed by the process, described in [`PROPOSALS.md`][proposals].
+Proposals to change the API of the `base` package are managed by the process, described in [`PROPOSALS.md`][proposals]. Bug fixes fall under the GHC developers purview, but CLC should be made aware of the change, and can ask for a proposal if the change is deemed significant.
 
 [proposals]: https://github.com/haskell/core-libraries-committee/blob/main/PROPOSALS.md
 


### PR DESCRIPTION
My understanding is that this is already the intended division of labour between GHC and CLC. So it would be good to write it down explicitly.

An instance of a bug fix is:
- a proposal is accepted, the proposer makes a mistake in the implementation, it's merged, we then notice. A second proposal is not required.
- There is a clear correctness issue in a `base` function with an obvious fix.

If there is any doubt about the change, then we should ask for it to be a proposal. But we also shouldn't get bogged down in process.