### PR TITLE
Add template-haskell-{lift,quasiquoter} to core libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ Current list of Core Libraries:
 * `random`,
 * `stm`,
 * `template-haskell`,
+* `template-haskell-lift`,
+* `template-haskell-quasiquoter`,
 * `terminfo`,
 * `text`,
 * `transformers`,


### PR DESCRIPTION
As approved in #379