### PR TITLE
Add aeson as a core library

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ The overall goals are
 
 Current list of Core Libraries:
 
+* `aeson`,
 * `array`,
 * `binary`,
 * `bytestring`,


### PR DESCRIPTION
See https://github.com/haskell/core-libraries-committee/issues/417